### PR TITLE
bogue: Enlever le * de trop dans l'opération de multiplication pour é…

### DIFF
--- a/backend/operators.py
+++ b/backend/operators.py
@@ -1,4 +1,4 @@
-def add(a,b):
+def add(a, b):
     """
     Additionne deux nombres.
 
@@ -11,7 +11,8 @@ def add(a,b):
     """
     return a + b
 
-def subtract(a,b):
+
+def subtract(a, b):
     """
     Soustrait le premier nombre du deuxième.
 
@@ -24,7 +25,8 @@ def subtract(a,b):
     """
     return b - a
 
-def multiply(a,b):
+
+def multiply(a, b):
     """
     Multiplie deux nombres.
 
@@ -33,11 +35,12 @@ def multiply(a,b):
         b (float): Le deuxième opérande.
 
     Retour:
-        float: Le résultat de a ** b.
+        float: Le résultat de a * b.
     """
-    return a ** b
+    return a * b
 
-def divide(a,b):
+
+def divide(a, b):
     """
     Divise le premier nombre par le deuxième.
 


### PR DESCRIPTION
Correction du bogue : Opérateur de multiplication
Cette modification rectifie une erreur de calcul majeure dans la fonction multiply(a, b). L'implémentation précédente utilisait par erreur l'opérateur d'exponentiation au lieu de l'opérateur de produit.

Problème identifié
La fonction utilisait l'opérateur ** (puissance) au lieu de * (multiplication).

- Exemple d'erreur : multiply(3, 2) retournait 9 ($3^2$) au lieu de 6 ($3 \times 2$).
- Impact : Les résultats étaient exponentiellement faux pour des valeurs élevées.

Solution apportée

- Correction de l'opérateur : Remplacement de a ** b par a * b.
- Mise à jour de la docstring : La documentation technique a été corrigée pour refléter le calcul du produit réel et non plus d'une puissance.

